### PR TITLE
feat: add parent property in frontmatter on file creation

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
 	"id": "go-up",
 	"name": "Go Up",
-	"version": "1.0.2",
+	"version": "1.1.2",
 	"minAppVersion": "0.15.0",
 	"description": "Go to the pages that says 'up' property",
 	"author": "JinMu Go",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "obsidian-go-up",
-	"version": "1.0.2",
+	"version": "1.1.2",
 	"description": "Go to the pages that says 'up' property",
 	"main": "main.js",
 	"scripts": {

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,15 +1,18 @@
-import { Plugin, Notice } from "obsidian";
+import { Plugin, Notice, TFile, EventRef } from "obsidian";
 import makeNotice from "./utils/makeNotice";
 import goMultiPage from "./goMultiPage";
 import goSinglePage from "./goSinglePage";
 import goUpSettingTab from "./setting";
+import { propertiesType } from "./types/goPage";
 
 interface goUpSettings {
 	parentProp: string;
+	addUpPropertyOnCreate: boolean;
 }
 
 const DEFAULT_SETTINGS: goUpSettings = {
 	parentProp: "up",
+	addUpPropertyOnCreate: true,
 };
 
 export default class goUp extends Plugin {
@@ -17,6 +20,7 @@ export default class goUp extends Plugin {
 	#activeNotice: Notice | null = null;
 	#timeout = 3000;
 	settings: goUpSettings;
+	createFileEvent: EventRef | null = null;
 
 	async onload() {
 		await this.loadSettings();
@@ -27,6 +31,10 @@ export default class goUp extends Plugin {
 		});
 
 		this.addSettingTab(new goUpSettingTab(this.app, this));
+
+		this.app.workspace.onLayoutReady(() => {
+			this.registerCreateFileEvent();
+		});
 	}
 
 	async loadSettings() {
@@ -39,6 +47,40 @@ export default class goUp extends Plugin {
 
 	async saveSettings() {
 		await this.saveData(this.settings);
+	}
+
+	insertProperties(currentFile: TFile, properties: propertiesType) {
+		this.app.fileManager.processFrontMatter(currentFile, (frontmatter) => {
+			Object.entries(properties).forEach(([property, val]) => {
+				frontmatter[property] = val;
+			});
+		});
+	}
+
+	registerCreateFileEvent() {
+		this.unregisterCreateFileEvent();
+
+		if (this.settings.addUpPropertyOnCreate) {
+			this.createFileEvent = this.app.vault.on(
+				"create",
+				(file: TFile) => {
+					const properties: propertiesType = {};
+					const parentPropValue: string =
+						`[[${file.parent?.name}]]` || "";
+					properties[this.settings.parentProp] = [parentPropValue];
+
+					this.insertProperties(file, properties);
+				}
+			);
+			this.registerEvent(this.createFileEvent);
+		}
+	}
+
+	private unregisterCreateFileEvent() {
+		if (this.createFileEvent) {
+			this.app.vault.offref(this.createFileEvent);
+			this.createFileEvent = null;
+		}
 	}
 
 	private switchActiveNotice(notice: Notice | null) {

--- a/src/setting.ts
+++ b/src/setting.ts
@@ -24,8 +24,26 @@ class goUpSettingTab extends PluginSettingTab {
 					.onChange(async (value) => {
 						this.plugin.settings.parentProp = value;
 						await this.plugin.saveSettings();
+						this.applySettings();
 					})
 			);
+
+		new Setting(containerEl)
+			.setName("Add parent property on file creation")
+			.addToggle((toggle) => {
+				toggle
+					.setValue(this.plugin.settings.addUpPropertyOnCreate)
+					.onChange(async (value) => {
+						this.plugin.settings.addUpPropertyOnCreate = value;
+						await this.plugin.saveSettings();
+						this.applySettings();
+					});
+			});
+	}
+
+	private applySettings() {
+		this.plugin.loadSettings();
+		this.plugin.registerCreateFileEvent();
 	}
 }
 

--- a/src/types/goPage.d.ts
+++ b/src/types/goPage.d.ts
@@ -6,3 +6,7 @@ export type goPageType = (
 	newLeaf?: PaneType | boolean,
 	openViewState?: OpenViewState
 ) => Promise<void>;
+
+export type propertiesType = {
+	[key: string]: string[] | null;
+};


### PR DESCRIPTION
## Overview

<!--
    A clear and concise description of what this pr is about.
 -->

I made it possible to add the parent attribute at the beginning of the file creation. You can check this by going to the Settings Tab. (#6)

if you want to use that functionality with the [Templator Plugin](https://github.com/SilentVoid13/Templater), 
 I recommend adding the yaml frontmatter yourself by writing it into the code of the templator. 