### PR TITLE
fix: approve esbuild & lefthook build scripts for pnpm 11

### DIFF
--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,7 +1,6 @@
+# pnpm 11 records an explicit build-script decision per dependency here.
+# Both ship native postinstall steps; allowing them avoids the install-time
+# ERR_PNPM_IGNORED_BUILDS failure (which otherwise breaks the pre-push hook).
 allowBuilds:
   esbuild: true
-  # Hooks are installed via the `prepare` script (lefthook install), so
-  # lefthook's own postinstall is not needed.
-  lefthook: false
-onlyBuiltDependencies:
-  - esbuild
+  lefthook: true


### PR DESCRIPTION
## Problem

pnpm 11 aborts installs with `ERR_PNPM_IGNORED_BUILDS` whenever a dependency has a build script with no recorded decision. The previous `pnpm-workspace.yaml` left **lefthook** undecided, so the implicit `pnpm install` that pnpm runs *before* the lefthook **pre-push `build` hook** exited non-zero — blocking every `git push`.

This was hit while releasing `1.2.0` (the tag push had to use `--no-verify` to bypass the broken hook).

## Fix

Record explicit `allowBuilds` decisions for the two deps that ship native postinstall steps:

```yaml
allowBuilds:
  esbuild: true
  lefthook: true
```

`onlyBuiltDependencies` is not honored by pnpm 11.0.3's interactive build-approval flow (it re-injects an `allowBuilds` stub), so the decision must live in `allowBuilds`.

## Verification

- `pnpm install` → no `ERR_PNPM_IGNORED_BUILDS`, lefthook postinstall runs cleanly, **no lockfile change** (CI `--frozen-lockfile` unaffected)
- `pnpm run build` (the pre-push hook command) → exit 0
- This branch was pushed **with the pre-push hook active (no `--no-verify`)** and it passed ✔️