### PR TITLE
fix: address Obsidian plugin review API warnings

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -104,7 +104,7 @@ export default class goUp extends Plugin {
 			`There is no upper page in "${this.settings.parentProp}" property`,
 			this.#timeout
 		);
-		activeWindow.setTimeout(() => this.switchActiveNotice(null), this.#timeout);
+		window.setTimeout(() => this.switchActiveNotice(null), this.#timeout);
 	}
 
 	private alertMustSettingParentProp() {
@@ -113,7 +113,7 @@ export default class goUp extends Plugin {
 			"Please set your parent property in the settings",
 			this.#timeout
 		);
-		activeWindow.setTimeout(() => this.switchActiveNotice(null), this.#timeout);
+		window.setTimeout(() => this.switchActiveNotice(null), this.#timeout);
 	}
 
 	private async goUp() {

--- a/src/telemetry.ts
+++ b/src/telemetry.ts
@@ -1,3 +1,5 @@
+import { Platform, requestUrl } from "obsidian";
+
 const ENDPOINT = (process.env.TELEMETRY_ENDPOINT as string) || "https://telemetry.jinmu.me";
 const API_KEY = (process.env.TELEMETRY_API_KEY as string) || "telemetry-dev-key";
 
@@ -12,6 +14,15 @@ interface TelemetryEvent {
 const FLUSH_INTERVAL = 2_000;
 const BATCH_THRESHOLD = 10;
 const MAX_QUEUE = 50;
+
+function detectPlatform(): string {
+    if (Platform.isMacOS) return "macos";
+    if (Platform.isWin) return "windows";
+    if (Platform.isLinux) return "linux";
+    if (Platform.isIosApp) return "ios";
+    if (Platform.isAndroidApp) return "android";
+    return "unknown";
+}
 
 export class Telemetry {
     private queue: TelemetryEvent[] = [];
@@ -36,7 +47,7 @@ export class Telemetry {
             app: this.app,
             event,
             context: {
-                platform: navigator.platform,
+                platform: detectPlatform(),
                 version: this.version,
                 obsidian: (window as unknown as { apiVersion?: string }).apiVersion,
             },
@@ -73,14 +84,15 @@ export class Telemetry {
         if (this.queue.length === 0) return;
         const batch = this.queue.splice(0);
         try {
-            await fetch(`${ENDPOINT}/v1/events/batch`, {
+            await requestUrl({
+                url: `${ENDPOINT}/v1/events/batch`,
                 method: "POST",
                 headers: {
                     "Content-Type": "application/json",
                     "X-API-Key": API_KEY,
                 },
                 body: JSON.stringify({ events: batch }),
-                keepalive: true,
+                throw: false,
             });
         } catch {
             // silently drop


### PR DESCRIPTION
Addresses the warnings/recommendations raised in the Obsidian plugin review.

## Changes
- **`src/main.ts`** — use `window.setTimeout()` instead of `activeWindow.setTimeout()` at both notice-timeout call sites.
- **`src/telemetry.ts`** — detect the OS via Obsidian's `Platform` API (`Platform.isMacOS` / `isWin` / `isLinux` / `isIosApp` / `isAndroidApp`) instead of the deprecated `navigator.platform`.
- **`src/telemetry.ts`** — use Obsidian's `requestUrl()` instead of `fetch()` for the telemetry batch request.

## Review items resolved
- ⚠️ `activeWindow.setTimeout()` → `window.setTimeout()` (`main.ts:107`, `main.ts:116`)
- ⚠️ navigator API for OS detection → `Platform` API (`telemetry.ts:39`)
- ⚠️ `fetch` → `requestUrl` (`telemetry.ts:76`)
- 💡 deprecated `navigator.platform` removed (`telemetry.ts:39`)

## Notes
`requestUrl` has no `keepalive` option, so the `shutdown()` flush is no longer guaranteed to complete during page unload — an inherent trade-off of the Obsidian-recommended API.

## Verification
`pnpm run build` (tsc + esbuild) passes; lint clean.