### PR TITLE
feat: go up by closing or keeping the current note

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,7 +4,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ## Project Overview
 
-**obsidian-go-up** is an Obsidian plugin that enables hierarchical navigation through notes by utilizing a customizable parent property in frontmatter. Users can navigate to parent pages via keyboard shortcut, supporting both single and multiple parent pages with a modal selection UI.
+**obsidian-go-up** is an Obsidian plugin that enables hierarchical navigation through notes by utilizing a customizable parent property in frontmatter. Users can navigate to parent pages via keyboard shortcut, supporting both single and multiple parent pages with a modal selection UI. Two commands are provided so the user can choose whether the current note is replaced or kept open when navigating up.
 
 ## Build & Development Commands
 
@@ -30,26 +30,31 @@ The build system uses esbuild configured in `esbuild.config.mjs`:
 ### Core Navigation Flow
 
 1. **main.ts** (`goUp` class) - Plugin entry point
-   - Registers the "Go upper page" command
+   - Registers two commands: "Navigate to parent page" (`mode: "replace"`) and "Navigate to parent page in new tab" (`mode: "new-tab"`)
    - Manages settings (customizable parent property name, auto-add on creation)
    - Reads frontmatter from active file using Obsidian's metadata cache
-   - Routes to `goSinglePage` or `goMultiPage` based on property type
+   - Routes to `goSinglePage` or `goMultiPage` based on property type, forwarding the `NavigationMode`
    - Uses private method `#goPage` bound to `app.workspace.openLinkText`
 
 2. **goSinglePage.ts** - Handles single parent navigation
    - Extracts page name from wiki-link format `[[PageName]]`
    - Resolves aliases to actual page names
-   - Directly navigates to parent page
+   - Delegates to `navigateToParent` with the requested mode
 
 3. **goMultiPage.ts** - Handles multiple parent navigation
    - Filters and normalizes array of parent links
-   - If only one valid parent remains, navigates directly
-   - Otherwise, opens `MultiPageModal` for user selection
+   - If only one valid parent remains, delegates to `navigateToParent`
+   - Otherwise, opens `MultiPageModal` for user selection (passing the mode through)
 
 4. **modal/MultiPageModal.ts** - Interactive parent selection
    - Extends `SuggestModal` from Obsidian API
    - Provides filtered search through available parent pages
-   - Executes navigation on selection
+   - On selection, delegates to `navigateToParent` with the mode
+
+5. **navigateToParent.ts** - Shared navigation behavior (single source of truth)
+   - `"new-tab"` (keep current open): focuses an already-open parent leaf, else opens a new tab
+   - `"replace"` (close current): if the current leaf is **pinned**, falls back to keep-open; if the parent is already open elsewhere, focuses it and `detach()`es the current leaf; otherwise replaces in place
+   - Captures the current leaf *before* navigating (focus moves), detects pin state via `leaf.getViewState().pinned`, and uses `revealLeaf` so sidebar/background tabs surface
 
 ### Utility Functions
 
@@ -58,6 +63,7 @@ Located in `src/utils/`:
 - **checkAlias.ts** - Detects if a page reference includes an alias (format: `[[page|alias]]`)
 - **getPageNameInAlias.ts** - Extracts actual page name from aliased references
 - **makeNotice.ts** - Creates temporary notification UI elements
+- **findOpenLeaf.ts** - Finds an already-open markdown leaf for a page, matching by resolved file **path** (not basename) to avoid same-name collisions; falls back to basename when the link can't be resolved
 
 ### Settings System
 
@@ -69,7 +75,7 @@ Located in `src/utils/`:
 ### Auto-Parent Feature
 
 When enabled (`addUpPropertyOnCreate: true`):
-- Listens to vault's `"create"` event (main.ts:60-77)
+- Listens to vault's `"create"` event (`registerCreateFileEvent` in main.ts)
 - Automatically adds parent property to new files
 - Sets value to `[[ParentFolderName]]` using file's parent directory
 - Uses `processFrontMatter` API for safe YAML manipulation
@@ -79,6 +85,7 @@ When enabled (`addUpPropertyOnCreate: true`):
 **types/goPage.d.ts**:
 - `goPageType` - Function signature matching Obsidian's `openLinkText` method
 - `propertiesType` - Frontmatter property structure (`{[key: string]: string[] | null}`)
+- `NavigationMode` - `"replace" | "new-tab"`, selecting whether the current note is closed or kept open
 
 ## Key Technical Details
 

--- a/README.md
+++ b/README.md
@@ -29,8 +29,20 @@ This plugin allows users to quickly navigate to a specified "parent" page by uti
     ---
     ```
 
-3. Use the Keyboard Shortcut: With the up property set, you can set the Keyboard Shortcut. <br />
-   i recommend `Cmd + Shift + U` to navigate to the specified parent page.
+3. Set a Hotkey: Open **Settings → Hotkeys**, search for "Go Up", and bind the command you want (see **Commands** below). <br />
+   I recommend `Cmd + Shift + U` to navigate to the specified parent page.
+
+
+# Commands
+
+The plugin adds two commands you can bind to separate hotkeys, depending on whether you want the current note to stay open:
+
+| Command | Behavior |
+| --- | --- |
+| **Navigate to parent page** | Replaces the current note with the parent. If the current note is **pinned**, it is kept open instead. If the parent is **already open** in another tab, that tab is focused and the current note is closed (no duplicate tab). |
+| **Navigate to parent page in new tab** | Keeps the current note open. If the parent is **already open**, focus simply switches to it; otherwise the parent opens in a new tab next to the current note. |
+
+When the `up` property lists multiple parents, a picker is shown first and the chosen parent then follows the behavior above.
 
 
 # Customize your own parent property

--- a/src/goMultiPage.ts
+++ b/src/goMultiPage.ts
@@ -1,11 +1,17 @@
 import { MultiPageModal } from "./modal/MultiPageModal";
-import { goPageType } from "./types/goPage";
+import { goPageType, NavigationMode } from "./types/goPage";
 import checkAlias from "./utils/checkAlias";
 import getPageName from "./utils/getPageName";
 import type { App } from "obsidian";
 import getPageNameInAlias from "./utils/getPageNameInAlias";
+import navigateToParent from "./navigateToParent";
 
-const goMultiPage = (upPages: Array<string>, goPage: goPageType, app: App) => {
+const goMultiPage = (
+	upPages: Array<string>,
+	goPage: goPageType,
+	app: App,
+	mode: NavigationMode
+) => {
 	upPages = upPages.reduce((prev: string[], upPage: string) => {
 		let pageName = getPageName(upPage);
 		if (pageName === null) {
@@ -19,9 +25,9 @@ const goMultiPage = (upPages: Array<string>, goPage: goPageType, app: App) => {
 	}, []);
 
 	if (upPages.length === 1) {
-		void goPage(upPages[0], "", false);
+		navigateToParent(app, goPage, upPages[0], mode);
 	} else {
-		new MultiPageModal(app, goPage, upPages).open();
+		new MultiPageModal(app, goPage, upPages, mode).open();
 	}
 };
 

--- a/src/goSinglePage.ts
+++ b/src/goSinglePage.ts
@@ -1,9 +1,16 @@
-import { goPageType } from "./types/goPage";
+import { App } from "obsidian";
+import { goPageType, NavigationMode } from "./types/goPage";
 import checkAlias from "./utils/checkAlias";
 import getPageName from "./utils/getPageName";
 import getPageNameInAlias from "./utils/getPageNameInAlias";
+import navigateToParent from "./navigateToParent";
 
-const goSinglePage = (upPage: string, goPage: goPageType) => {
+const goSinglePage = (
+	upPage: string,
+	goPage: goPageType,
+	app: App,
+	mode: NavigationMode
+) => {
 	let upPageName = getPageName(upPage);
 
 	if (upPageName === null) {
@@ -12,7 +19,8 @@ const goSinglePage = (upPage: string, goPage: goPageType) => {
 	if (checkAlias(upPageName)) {
 		upPageName = getPageNameInAlias(upPageName);
 	}
-	void goPage(upPageName, "", false);
+
+	navigateToParent(app, goPage, upPageName, mode);
 };
 
 export default goSinglePage;

--- a/src/main.ts
+++ b/src/main.ts
@@ -3,7 +3,7 @@ import makeNotice from "./utils/makeNotice";
 import goMultiPage from "./goMultiPage";
 import goSinglePage from "./goSinglePage";
 import goUpSettingTab from "./setting";
-import { propertiesType } from "./types/goPage";
+import { propertiesType, NavigationMode } from "./types/goPage";
 import { Telemetry } from "./telemetry";
 
 interface goUpSettings {
@@ -33,7 +33,13 @@ export default class goUp extends Plugin {
 		this.addCommand({
 			id: "upper-page",
 			name: "Navigate to parent page",
-			callback: this.goUp.bind(this),
+			callback: () => this.goUp("replace"),
+		});
+
+		this.addCommand({
+			id: "upper-page-new-tab",
+			name: "Navigate to parent page in new tab",
+			callback: () => this.goUp("new-tab"),
 		});
 
 		this.addSettingTab(new goUpSettingTab(this.app, this));
@@ -116,7 +122,7 @@ export default class goUp extends Plugin {
 		window.setTimeout(() => this.switchActiveNotice(null), this.#timeout);
 	}
 
-	private async goUp() {
+	private async goUp(mode: NavigationMode) {
 		if (
 			this.settings.parentProp === "" ||
 			this.settings.parentProp === null
@@ -137,10 +143,10 @@ export default class goUp extends Plugin {
 
 		if (Array.isArray(upProperty)) {
 			this.telemetry.track("upper_page_invoked", { mode: "multi" });
-			goMultiPage(upProperty, this.#goPage, this.app);
+			goMultiPage(upProperty, this.#goPage, this.app, mode);
 		} else {
 			this.telemetry.track("upper_page_invoked", { mode: "single" });
-			goSinglePage(upProperty, this.#goPage);
+			goSinglePage(upProperty, this.#goPage, this.app, mode);
 		}
 	}
 }

--- a/src/modal/MultiPageModal.ts
+++ b/src/modal/MultiPageModal.ts
@@ -1,32 +1,37 @@
 import { App, SuggestModal } from "obsidian";
-import { goPageType } from "src/types/goPage";
+import { goPageType, NavigationMode } from "src/types/goPage";
+import navigateToParent from "src/navigateToParent";
 
 type pageType = string;
 
 export class MultiPageModal extends SuggestModal<pageType> {
 	upPages: pageType[];
 	goPage: goPageType;
+	mode: NavigationMode;
 
-	constructor(app: App, goPage: goPageType, upPages: pageType[]) {
+	constructor(
+		app: App,
+		goPage: goPageType,
+		upPages: pageType[],
+		mode: NavigationMode
+	) {
 		super(app);
 		this.upPages = upPages;
 		this.goPage = goPage;
+		this.mode = mode;
 	}
 
-	// Returns all available suggestions.
 	getSuggestions(query: string): pageType[] {
 		return this.upPages.filter((page) => {
 			return page.toLowerCase().includes(query.toLowerCase());
 		});
 	}
 
-	// Renders each suggestion item.
 	renderSuggestion(page: pageType, el: HTMLElement) {
 		el.createDiv({ text: page ?? undefined });
 	}
 
-	// Perform action on the selected suggestion.
 	onChooseSuggestion(page: pageType, _evt: MouseEvent | KeyboardEvent) {
-		void this.goPage(page, "", false);
+		navigateToParent(this.app, this.goPage, page, this.mode);
 	}
 }

--- a/src/navigateToParent.ts
+++ b/src/navigateToParent.ts
@@ -1,0 +1,67 @@
+import { App, MarkdownView, WorkspaceLeaf } from "obsidian";
+import { goPageType, NavigationMode } from "./types/goPage";
+import findOpenLeaf from "./utils/findOpenLeaf";
+
+/** Brings an already-open leaf to the foreground, uncollapsing a sidebar if needed. */
+const focusLeaf = (app: App, leaf: WorkspaceLeaf) => {
+	app.workspace.setActiveLeaf(leaf, { focus: true });
+	void app.workspace.revealLeaf(leaf);
+};
+
+/**
+ * "Keep current note open" behavior:
+ * - parent already open somewhere -> just switch focus to it
+ * - parent not open -> open it in a new tab next to the current note
+ */
+const goKeepOpen = (app: App, goPage: goPageType, pageName: string) => {
+	const existing = findOpenLeaf(app, pageName);
+	if (existing) {
+		focusLeaf(app, existing);
+		return;
+	}
+	void goPage(pageName, "", "tab");
+};
+
+/**
+ * Navigates to a parent page according to the requested mode.
+ *
+ * "new-tab"  -> keep the current note open (focus existing parent, else new tab).
+ * "replace"  -> close the current note:
+ *   - if the current note is pinned, fall back to keep-open behavior;
+ *   - if the parent is already open elsewhere, focus it and close the current note;
+ *   - otherwise replace the current note in place.
+ */
+const navigateToParent = (
+	app: App,
+	goPage: goPageType,
+	pageName: string,
+	mode: NavigationMode
+) => {
+	if (mode === "new-tab") {
+		goKeepOpen(app, goPage, pageName);
+		return;
+	}
+
+	// mode === "replace"
+	// Capture the current leaf up front: navigation moves focus, so reading the
+	// "active" leaf afterwards would no longer point at the note we want to close.
+	const currentLeaf =
+		app.workspace.getActiveViewOfType(MarkdownView)?.leaf ?? null;
+	const isPinned = currentLeaf?.getViewState().pinned === true;
+
+	if (isPinned) {
+		goKeepOpen(app, goPage, pageName);
+		return;
+	}
+
+	const existing = findOpenLeaf(app, pageName);
+	if (existing) {
+		focusLeaf(app, existing);
+		currentLeaf?.detach();
+		return;
+	}
+
+	void goPage(pageName, "", false);
+};
+
+export default navigateToParent;

--- a/src/types/goPage.d.ts
+++ b/src/types/goPage.d.ts
@@ -10,3 +10,5 @@ export type goPageType = (
 export type propertiesType = {
 	[key: string]: string[] | null;
 };
+
+export type NavigationMode = "replace" | "new-tab";

--- a/src/utils/findOpenLeaf.ts
+++ b/src/utils/findOpenLeaf.ts
@@ -1,0 +1,31 @@
+import { App, MarkdownView, WorkspaceLeaf } from "obsidian";
+
+/**
+ * Finds an already-open markdown leaf showing the given page.
+ *
+ * Resolves the link target to a concrete TFile and matches on full path so
+ * that two notes sharing a basename in different folders are not confused.
+ * Falls back to basename matching only when the link cannot be resolved.
+ */
+const findOpenLeaf = (app: App, pageName: string): WorkspaceLeaf | null => {
+	const target = app.metadataCache.getFirstLinkpathDest(pageName, "");
+	const leaves = app.workspace.getLeavesOfType("markdown");
+
+	for (const leaf of leaves) {
+		const view = leaf.view as MarkdownView;
+		const file = view.file;
+		if (file === null || file === undefined) {
+			continue;
+		}
+		if (target) {
+			if (file.path === target.path) {
+				return leaf;
+			}
+		} else if (file.basename === pageName) {
+			return leaf;
+		}
+	}
+	return null;
+};
+
+export default findOpenLeaf;


### PR DESCRIPTION
## Summary

Resolves #12 — adds the ability to choose whether the current note stays open or is replaced when navigating to a parent page, via two separately bindable commands.

- **Navigate to parent page** (replace / *go up and close*)
  - if the current note is **pinned** → falls back to keep-open behavior
  - if the parent is **already open** elsewhere → focuses it and **closes** the current note (no duplicate tab)
  - otherwise → replaces the current note in place
- **Navigate to parent page in new tab** (keep open)
  - if the parent is **already open** elsewhere → just switches focus to it
  - otherwise → opens it in a **new tab** next to the current note

## Implementation

- New `navigateToParent` helper consolidates the branching that was duplicated across `goSinglePage`, `goMultiPage`, and `MultiPageModal`.
- `findOpenLeaf` matches already-open parents by **file path** (not basename, avoiding same-name collisions) and focus uses `revealLeaf` so sidebar/background tabs surface.
- Pinned detection via the public `leaf.getViewState().pinned`; closing via `leaf.detach()` (current leaf captured before navigation).

## Verification

Drove the real command dispatch against a running vault and observed workspace leaf state (path / pinned / active) before & after each invocation. All 5 spec cases + a pinned-and-parent-already-open probe passed:

| Case | Result |
|---|---|
| replace / parent not open | ✅ reused leaf in place |
| replace / parent already open | ✅ current closed, existing parent focused, no duplicate |
| replace / current pinned | ✅ pinned note kept, fell back to keep-open |
| new-tab / parent not open | ✅ opened in new tab, current kept |
| new-tab / parent already open | ✅ focused existing, no duplicate |
| 🔍 replace / pinned + parent already open | ✅ pinned kept, existing parent focused, no new tab |